### PR TITLE
3A-G04-W004-PR01. Creation of Component Props Interface

### DIFF
--- a/app/admin/layout.tsx
+++ b/app/admin/layout.tsx
@@ -8,6 +8,10 @@ import { useAuth } from '@/context/AuthContext';
 import { useAdminTab } from '@/context/AdminTabContext';
 import { normalizeRole, USER_ROLES } from '@/lib/domain/roles';
 
+interface AdminLayoutProps {
+  children: React.ReactNode;
+}
+
 function LoadingState() {
   return (
     <div className="min-h-screen flex items-center justify-center">
@@ -38,7 +42,7 @@ function LoadingState() {
   );
 }
 
-export default function AdminLayout({ children }: { children: React.ReactNode }) {
+export default function AdminLayout({ children }: Readonly<AdminLayoutProps>) {
   const { firebaseUser, profile, loading, logout } = useAuth();
   const { activeTab, setActiveTab } = useAdminTab();
   const router = useRouter();

--- a/app/dashboard/DashboardLayoutClient.tsx
+++ b/app/dashboard/DashboardLayoutClient.tsx
@@ -8,7 +8,11 @@ import { useAdminTab } from '@/context/AdminTabContext';
 import { USER_ROLES } from '@/lib/domain/roles';
 import Link from 'next/link';
 
-function DashboardLayoutInner({ children }: { children: React.ReactNode }) {
+interface DashboardLayoutProps {
+  children: React.ReactNode;
+}
+
+function DashboardLayoutInner({ children }: Readonly<DashboardLayoutProps>) {
   const { firebaseUser, profile, loading, logout } = useAuth();
   const router = useRouter();
   const pathname = usePathname();
@@ -234,6 +238,6 @@ function DashboardLayoutInner({ children }: { children: React.ReactNode }) {
   );
 }
 
-export default function DashboardLayout({ children }: { children: React.ReactNode }) {
+export default function DashboardLayout({ children }: Readonly<DashboardLayoutProps>) {
   return <DashboardLayoutInner>{children}</DashboardLayoutInner>;
 }

--- a/app/dashboard/inbox/page.tsx
+++ b/app/dashboard/inbox/page.tsx
@@ -24,7 +24,35 @@ import {
 } from '@/lib/reservations';
 import { useAdminTab } from '@/context/AdminTabContext';
 
-function StatusBadge({ status }: { status: string }) {
+interface StatusBadgeProps {
+  status: string;
+}
+
+interface ReservationApprovalsProps {
+  email: string;
+  targetReservationId: string | null;
+}
+
+interface ReservationUpdatesProps {
+  notifications: Notification[];
+}
+
+interface TypeIconProps {
+  type: string;
+}
+
+interface AdminMessagesProps {
+  uid: string;
+}
+
+interface UserInboxProps {
+  uid: string;
+  email: string;
+  isFaculty: boolean;
+  showStaffMessages: boolean;
+}
+
+function StatusBadge({ status }: Readonly<StatusBadgeProps>) {
   const style = (() => {
     switch (status) {
       case 'open':
@@ -76,10 +104,7 @@ function formatEquipment(equipment?: Record<string, number>) {
 function ReservationApprovals({
   email,
   targetReservationId,
-}: {
-  email: string;
-  targetReservationId: string | null;
-}) {
+}: Readonly<ReservationApprovalsProps>) {
   const { firebaseUser, profile } = useAuth();
   const [requests, setRequests] = useState<Reservation[]>([]);
   const [actionLoading, setActionLoading] = useState<string | null>(null);
@@ -360,9 +385,7 @@ function ReservationApprovals({
 
 function ReservationUpdates({
   notifications,
-}: {
-  notifications: Notification[];
-}) {
+}: Readonly<ReservationUpdatesProps>) {
   const reservationNotifications = useMemo(
     () =>
       notifications.filter((notification) =>
@@ -434,12 +457,12 @@ function ReservationUpdates({
   );
 }
 
-function TypeIcon({ type }: { type: string }) {
+function TypeIcon({ type }: Readonly<TypeIconProps>) {
   const icons: Record<string, string> = { equipment: '🔧', general: '💬', other: '📋' };
   return <span className="mr-1">{icons[type] || '📋'}</span>;
 }
 
-function AdminMessages({ uid }: { uid: string }) {
+function AdminMessages({ uid }: Readonly<AdminMessagesProps>) {
   const [requests, setRequests] = useState<AdminRequest[]>([]);
   const [filter, setFilter] = useState<'all' | 'open' | 'responded' | 'closed'>('all');
   const [expandedId, setExpandedId] = useState<string | null>(null);
@@ -579,12 +602,7 @@ function UserInbox({
   email,
   isFaculty,
   showStaffMessages,
-}: {
-  uid: string;
-  email: string;
-  isFaculty: boolean;
-  showStaffMessages: boolean;
-}) {
+}: Readonly<UserInboxProps>) {
   const [notifications, setNotifications] = useState<Notification[]>([]);
   const searchParams = useSearchParams();
   const targetReservationId = searchParams.get('reservationId');

--- a/app/dashboard/layout.tsx
+++ b/app/dashboard/layout.tsx
@@ -5,6 +5,10 @@ export const metadata: Metadata = {
   title: "IRoomReserve | Dashboard",
 }
 
-export default function DashboardLayout({ children }: { children: React.ReactNode }) {
+interface DashboardLayoutProps {
+  children: React.ReactNode;
+}
+
+export default function DashboardLayout({ children }: Readonly<DashboardLayoutProps>) {
   return <DashboardLayoutClient>{children}</DashboardLayoutClient>
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -41,11 +41,13 @@ export const metadata: Metadata = {
   manifest: "/manifest.json",
 };
 
+interface RootLayoutProps {
+  children: React.ReactNode;
+}
+
 export default function RootLayout({
   children,
-}: Readonly<{
-  children: React.ReactNode;
-}>) {
+}: Readonly<RootLayoutProps>) {
   return (
     <html lang="en" className="bg-[#f8f9fa]">
       <body className={`min-h-screen bg-[#f8f9fa] ${centuryGothicRegular.variable} ${centuryGothicBold.variable}`}>

--- a/app/register/page.tsx
+++ b/app/register/page.tsx
@@ -7,6 +7,10 @@ import Toast from '@/components/Toast';
 import { USER_ROLES } from '@/lib/domain/roles';
 import { registerWithEmail, getAuthErrorMessage } from '@/lib/auth';
 
+interface EyeIconProps {
+  open: boolean;
+}
+
 function RegisterForm() {
   type VantaEffectHandle = {
     destroy: () => void;
@@ -150,7 +154,7 @@ function RegisterForm() {
     }
   };
 
-  const EyeIcon = ({ open }: { open: boolean }) => open ? (
+  const EyeIcon = ({ open }: Readonly<EyeIconProps>) => open ? (
     <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
       <path strokeLinecap="round" strokeLinejoin="round" d="M13.875 18.825A10.05 10.05 0 0112 19c-5 0-9.27-3.11-11-7.5a11.72 11.72 0 013.168-4.477M6.343 6.343A9.97 9.97 0 0112 5c5 0 9.27 3.11 11 7.5a11.72 11.72 0 01-4.168 4.477M6.343 6.343L3 3m3.343 3.343l2.829 2.829m4.243 4.243L17.657 17.657M17.657 17.657L21 21m-3.343-3.343l-2.829-2.829a3 3 0 00-4.243-4.243" />
     </svg>

--- a/components/AuthAlert.tsx
+++ b/components/AuthAlert.tsx
@@ -58,7 +58,7 @@ export default function AuthAlert({
   message,
   tone = 'error',
   className = '',
-}: AuthAlertProps) {
+}: Readonly<AuthAlertProps>) {
   return (
     <div
       role="alert"

--- a/components/BeaconStatusSection.tsx
+++ b/components/BeaconStatusSection.tsx
@@ -18,7 +18,7 @@ export default function BeaconStatusSection({
   buildingName,
   rooms,
   title = 'Beacon Status',
-}: BeaconStatusSectionProps) {
+}: Readonly<BeaconStatusSectionProps>) {
   const sortedRooms = [...rooms].sort(compareRooms);
   const occupiedCount = rooms.filter((room) => room.beaconConnected).length;
   const availableCount = rooms.length - occupiedCount;

--- a/components/BleAdminMonitor.tsx
+++ b/components/BleAdminMonitor.tsx
@@ -66,7 +66,7 @@ export default function BleAdminMonitor({
   rooms,
   className = '',
   pollIntervalMs = BLE_MONITOR_REFRESH_INTERVAL_MS,
-}: BleAdminMonitorProps) {
+}: Readonly<BleAdminMonitorProps>) {
   const [occupancyData, setOccupancyData] = useState<OccupancyPayload>(
     DEFAULT_OCCUPANCY_PAYLOAD
   );

--- a/components/BleStatus.tsx
+++ b/components/BleStatus.tsx
@@ -79,7 +79,7 @@ export default function BleStatus({
   room,
   className = '',
   pollIntervalMs = BLE_MONITOR_REFRESH_INTERVAL_MS,
-}: BleStatusProps) {
+}: Readonly<BleStatusProps>) {
   const { firebaseUser, loading } = useAuth();
   const [occupancyStatus, setOccupancyStatus] = useState<OccupancyPayload>(
     DEFAULT_OCCUPANCY_PAYLOAD

--- a/components/BleStatusBadge.tsx
+++ b/components/BleStatusBadge.tsx
@@ -49,7 +49,7 @@ export default function BleStatusBadge({
   status,
   label,
   className = '',
-}: BleStatusBadgeProps) {
+}: Readonly<BleStatusBadgeProps>) {
   const theme = getBleBadgeTheme(status);
 
   return (

--- a/components/BleSummaryCard.tsx
+++ b/components/BleSummaryCard.tsx
@@ -49,7 +49,7 @@ export default function BleSummaryCard({
   pollIntervalMs = BLE_MONITOR_REFRESH_INTERVAL_MS,
   detailsHref = '/dashboard/room-status',
   onViewDetails,
-}: BleSummaryCardProps) {
+}: Readonly<BleSummaryCardProps>) {
   const [occupancyData, setOccupancyData] = useState<OccupancyPayload>(
     DEFAULT_OCCUPANCY_PAYLOAD
   );

--- a/components/NavBar.tsx
+++ b/components/NavBar.tsx
@@ -26,6 +26,10 @@ interface NavBarProps {
   onTabChange?: (tab: AdminTab) => void;
 }
 
+interface ChevronDownIconProps {
+  open: boolean;
+}
+
 const adminLinks: Array<{ label: string; tab: AdminTab }> = [
   { label: 'Dashboard', tab: 'dashboard' },
   { label: 'Pending', tab: 'pending' },
@@ -47,7 +51,7 @@ const navItemActiveClasses = 'bg-transparent text-[#a12124] shadow-none';
 const navItemInactiveClasses =
   'bg-transparent text-[#343434] hover:bg-transparent hover:text-[#a12124] hover:shadow-none';
 
-function ChevronDownIcon({ open }: { open: boolean }) {
+function ChevronDownIcon({ open }: Readonly<ChevronDownIconProps>) {
   return (
     <svg
       className={`w-4 h-4 transition-transform duration-200 ${open ? 'rotate-180' : ''}`}
@@ -65,7 +69,7 @@ function ChevronDownIcon({ open }: { open: boolean }) {
   );
 }
 
-const NavBar: React.FC<NavBarProps> = ({
+const NavBar: React.FC<Readonly<NavBarProps>> = ({
   user,
   onLogout,
   activeTab,

--- a/components/Providers.tsx
+++ b/components/Providers.tsx
@@ -3,7 +3,11 @@
 import { AuthProvider } from '@/context/AuthContext';
 import { AdminTabProvider } from '@/context/AdminTabContext';
 
-export default function Providers({ children }: { children: React.ReactNode }) {
+interface ProvidersProps {
+  children: React.ReactNode;
+}
+
+export default function Providers({ children }: Readonly<ProvidersProps>) {
   return (
     <AuthProvider>
       <AdminTabProvider>{children}</AdminTabProvider>

--- a/components/RoomAssistantWidget.tsx
+++ b/components/RoomAssistantWidget.tsx
@@ -302,7 +302,7 @@ export default function RoomAssistantWidget({
   selectedRoom = null,
   selectedRoomAvailable = null,
   timeslot,
-}: RoomAssistantWidgetProps) {
+}: Readonly<RoomAssistantWidgetProps>) {
   const welcomeMessage = useMemo(() => createWelcomeMessage(), []);
   const [isOpen, setIsOpen] = useState(false);
   const [messages, setMessages] = useState<AssistantMessage[]>([welcomeMessage]);

--- a/components/RoomAvailabilityPicker.tsx
+++ b/components/RoomAvailabilityPicker.tsx
@@ -46,7 +46,7 @@ export default function RoomAvailabilityPicker({
   loading = false,
   hideLegend = false,
   className = '',
-}: RoomAvailabilityPickerProps) {
+}: Readonly<RoomAvailabilityPickerProps>) {
   const minSelectable = minDate ?? todayAtMidnight;
 
   const bookedDateObjects = useMemo(

--- a/components/RoomCard.tsx
+++ b/components/RoomCard.tsx
@@ -32,7 +32,7 @@ export default function RoomCard({
   name,
   onClick,
   roomType,
-}: RoomCardProps) {
+}: Readonly<RoomCardProps>) {
   const isAvailable = availability === 'Available';
 
   return (

--- a/components/StatusBadge.tsx
+++ b/components/StatusBadge.tsx
@@ -71,7 +71,7 @@ function getBadgeLabel(status: string): string {
   }
 }
 
-const StatusBadge: React.FC<StatusBadgeProps> = ({ status, className = '' }) => {
+const StatusBadge: React.FC<Readonly<StatusBadgeProps>> = ({ status, className = '' }) => {
   return (
     <span
       className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-bold border leading-5 ${getBadgeStyle(status)} ${className}`.trim()}

--- a/components/SummaryCard.tsx
+++ b/components/SummaryCard.tsx
@@ -9,7 +9,7 @@ interface SummaryCardProps {
   color: string;
 }
 
-const SummaryCard: React.FC<SummaryCardProps> = ({ icon, number, label, color }) => {
+const SummaryCard: React.FC<Readonly<SummaryCardProps>> = ({ icon, number, label, color }) => {
   return (
     <div className={`glass-card p-6 border-l-4 ${color}`}>
       <div className="flex items-center">

--- a/components/Toast.tsx
+++ b/components/Toast.tsx
@@ -10,7 +10,7 @@ interface ToastProps {
   duration?: number;
 }
 
-export default function Toast({ message, type = 'success', show, onClose, duration = 3000 }: ToastProps) {
+export default function Toast({ message, type = 'success', show, onClose, duration = 3000 }: Readonly<ToastProps>) {
   const [visible, setVisible] = useState(false);
   const [animating, setAnimating] = useState(false);
 

--- a/components/admin/AdminClassSchedulesSection.tsx
+++ b/components/admin/AdminClassSchedulesSection.tsx
@@ -52,7 +52,7 @@ export default function AdminClassSchedulesSection({
   onEditSchedule,
   onDeleteSchedule,
   className = '',
-}: AdminClassSchedulesSectionProps) {
+}: Readonly<AdminClassSchedulesSectionProps>) {
   return (
     <section className={className}>
       <div className="flex items-center justify-between mb-4">

--- a/components/admin/AdminNoBuildingAssigned.tsx
+++ b/components/admin/AdminNoBuildingAssigned.tsx
@@ -8,7 +8,7 @@ interface AdminNoBuildingAssignedProps {
 export default function AdminNoBuildingAssigned({
   title = 'No Building Assigned',
   description = 'Your account has been approved, but the Super Admin has not yet assigned a building to you. Please contact the Super Admin to get a building assignment.',
-}: AdminNoBuildingAssignedProps) {
+}: Readonly<AdminNoBuildingAssignedProps>) {
   return (
     <div className="glass-card p-12 text-center">
       <div className="w-16 h-16 rounded-full bg-yellow-500/10 flex items-center justify-center mx-auto mb-4">

--- a/components/admin/AdminPageHeader.tsx
+++ b/components/admin/AdminPageHeader.tsx
@@ -22,7 +22,7 @@ export default function AdminPageHeader({
   buildingName,
   activeBuildingLabel,
   onBuildingChange,
-}: AdminPageHeaderProps) {
+}: Readonly<AdminPageHeaderProps>) {
   return (
     <section className="mb-8 flex flex-col gap-5 lg:flex-row lg:items-start lg:justify-between">
       <div className="backdrop-blur-md bg-white/40 rounded-xl px-6 py-4 border border-white/30">

--- a/components/admin/AdminRoomStatusSection.tsx
+++ b/components/admin/AdminRoomStatusSection.tsx
@@ -18,7 +18,11 @@ interface AdminRoomStatusSectionProps {
   className?: string;
 }
 
-function StatusBadge({ status }: { status: string }) {
+interface StatusBadgeProps {
+  status: string;
+}
+
+function StatusBadge({ status }: Readonly<StatusBadgeProps>) {
   const style = (() => {
     switch (status) {
       case 'Ongoing':
@@ -50,7 +54,7 @@ export default function AdminRoomStatusSection({
   computeEffectiveStatus,
   onStatusChange,
   className = '',
-}: AdminRoomStatusSectionProps) {
+}: Readonly<AdminRoomStatusSectionProps>) {
   return (
     <section className={className}>
       <div className="backdrop-blur-md bg-white/40 rounded-xl px-6 py-4 border border-white/30 inline-block mb-6">

--- a/components/dashboards/AdminDashboard.tsx
+++ b/components/dashboards/AdminDashboard.tsx
@@ -56,8 +56,20 @@ import { fetchAdminDashboardSnapshot } from '@/lib/adminDashboard';
 import { getManagedBuildingsForCampus } from '@/lib/campusAssignments';
 import { normalizeRoomCheckInMethod } from '@/lib/roomStatus';
 
+interface RoleBadgeProps {
+  role: string;
+}
+
+interface StatusBadgeProps {
+  status: string;
+}
+
+interface StarRatingProps {
+  rating: number;
+}
+
 // ─── Helpers ────────────────────────────────────────────────────
-function RoleBadge({ role }: { role: string }) {
+function RoleBadge({ role }: Readonly<RoleBadgeProps>) {
   const style = role === 'Faculty'
     ? 'ui-badge-green'
     : 'ui-badge-blue';
@@ -68,7 +80,7 @@ function RoleBadge({ role }: { role: string }) {
   );
 }
 
-function StatusBadge({ status }: { status: string }) {
+function StatusBadge({ status }: Readonly<StatusBadgeProps>) {
   const style = (() => {
     switch (status) {
       case 'Occupied': return 'ui-badge-red';
@@ -105,7 +117,7 @@ function getSentimentBadgeClasses(label: string) {
   return 'border-slate-500/25 bg-slate-500/10 text-slate-700';
 }
 
-function StarRating({ rating }: { rating: number }) {
+function StarRating({ rating }: Readonly<StarRatingProps>) {
   return (
     <div className="flex items-center gap-0.5">
       {[1, 2, 3, 4, 5].map((star) => (
@@ -221,7 +233,7 @@ interface AdminDashboardProps {
   activeTab: AdminTab;
 }
 
-export default function AdminDashboard({ firstName, activeTab }: AdminDashboardProps) {
+export default function AdminDashboard({ firstName, activeTab }: Readonly<AdminDashboardProps>) {
   const { firebaseUser, profile } = useAuth();
   const { setActiveTab, selectedBuildingId, setSelectedBuildingId } = useAdminTab();
   const managedBuildings = useMemo(

--- a/components/dashboards/FacultyDashboard.tsx
+++ b/components/dashboards/FacultyDashboard.tsx
@@ -9,6 +9,6 @@ interface FacultyDashboardProps {
 
 export default function FacultyDashboard({
   firstName,
-}: FacultyDashboardProps) {
+}: Readonly<FacultyDashboardProps>) {
   return <MemberDashboard firstName={firstName} welcomeEmoji="📚" />;
 }

--- a/components/dashboards/MemberDashboard.tsx
+++ b/components/dashboards/MemberDashboard.tsx
@@ -39,7 +39,7 @@ interface MemberDashboardProps {
 export default function MemberDashboard({
   firstName,
   welcomeEmoji,
-}: MemberDashboardProps) {
+}: Readonly<MemberDashboardProps>) {
   const { firebaseUser } = useAuth();
   const router = useRouter();
   const uid = firebaseUser?.uid;

--- a/components/dashboards/StudentDashboard.tsx
+++ b/components/dashboards/StudentDashboard.tsx
@@ -9,6 +9,6 @@ interface StudentDashboardProps {
 
 export default function StudentDashboard({
   firstName,
-}: StudentDashboardProps) {
+}: Readonly<StudentDashboardProps>) {
   return <MemberDashboard firstName={firstName} welcomeEmoji="🎓" />;
 }

--- a/components/dashboards/UtilityStaffDashboard.tsx
+++ b/components/dashboards/UtilityStaffDashboard.tsx
@@ -37,7 +37,7 @@ interface UtilityStaffDashboardProps {
 
 export default function UtilityStaffDashboard({
   firstName,
-}: UtilityStaffDashboardProps) {
+}: Readonly<UtilityStaffDashboardProps>) {
   const { firebaseUser, profile } = useAuth();
   const uid = firebaseUser?.uid;
   const managedBuildings = getManagedBuildingsForCampus(profile?.campus);

--- a/components/messages/ComposeModal.tsx
+++ b/components/messages/ComposeModal.tsx
@@ -27,7 +27,7 @@ export default function ComposeModal({
   initialRecipientId = '',
   initialSubject = '',
   initialBody = '',
-}: ComposeModalProps) {
+}: Readonly<ComposeModalProps>) {
   const { firebaseUser, profile } = useAuth();
   const [recipients, setRecipients] = useState<MessageRecipient[]>([]);
   const [recipientsError, setRecipientsError] = useState('');

--- a/components/messages/MessagesSection.tsx
+++ b/components/messages/MessagesSection.tsx
@@ -53,7 +53,7 @@ function getInitials(name: string): string {
 export default function MessagesSection({
   title = 'Messages',
   subtitle = 'Direct messages with other building staff and administrators.',
-}: MessagesSectionProps) {
+}: Readonly<MessagesSectionProps>) {
   const { firebaseUser, profile } = useAuth();
   const [folder, setFolder] = useState<MessageFolder>('inbox');
   const [inbox, setInbox] = useState<Message[]>([]);

--- a/components/room-status/BuildingSection.tsx
+++ b/components/room-status/BuildingSection.tsx
@@ -12,7 +12,7 @@ interface BuildingSectionProps {
 export default function BuildingSection({
   building,
   floors,
-}: BuildingSectionProps) {
+}: Readonly<BuildingSectionProps>) {
   return (
     <section className="glass-card p-4 sm:p-5">
       <div className="mb-4">

--- a/components/room-status/CampusSelector.tsx
+++ b/components/room-status/CampusSelector.tsx
@@ -13,7 +13,7 @@ export default function CampusSelector({
   onChange,
   options,
   value,
-}: CampusSelectorProps) {
+}: Readonly<CampusSelectorProps>) {
   if (options.length === 0) {
     return null;
   }

--- a/components/room-status/FloorAccordion.tsx
+++ b/components/room-status/FloorAccordion.tsx
@@ -12,7 +12,7 @@ export default function FloorAccordion({
   floor,
   roomCount,
   renderContent,
-}: FloorAccordionProps) {
+}: Readonly<FloorAccordionProps>) {
   const [isOpen, setIsOpen] = useState(false);
 
   return (

--- a/components/room-status/RoomList.tsx
+++ b/components/room-status/RoomList.tsx
@@ -30,7 +30,7 @@ function getReservationMeta(item: RoomStatusViewItem) {
   return 'No active reservation';
 }
 
-export default function RoomList({ items }: RoomListProps) {
+export default function RoomList({ items }: Readonly<RoomListProps>) {
   if (items.length === 0) {
     return (
       <div className="rounded-2xl border border-dark/10 bg-dark/5 p-6 text-center">

--- a/context/AdminTabContext.tsx
+++ b/context/AdminTabContext.tsx
@@ -10,6 +10,10 @@ interface AdminTabContextType {
   setSelectedBuildingId: (buildingId: string) => void;
 }
 
+interface AdminTabProviderProps {
+  children: React.ReactNode;
+}
+
 const AdminTabContext = createContext<AdminTabContextType>({
   activeTab: 'dashboard',
   setActiveTab: () => {},
@@ -17,7 +21,7 @@ const AdminTabContext = createContext<AdminTabContextType>({
   setSelectedBuildingId: () => {},
 });
 
-export function AdminTabProvider({ children }: { children: React.ReactNode }) {
+export function AdminTabProvider({ children }: Readonly<AdminTabProviderProps>) {
   const [activeTab, setActiveTab] = useState<AdminTab>('dashboard');
   const [selectedBuildingId, setSelectedBuildingId] = useState('');
   return (

--- a/context/AuthContext.tsx
+++ b/context/AuthContext.tsx
@@ -24,6 +24,10 @@ interface AuthContextType {
   logout: () => Promise<void>;
 }
 
+interface AuthProviderProps {
+  children: React.ReactNode;
+}
+
 const AuthContext = createContext<AuthContextType>({
   firebaseUser: null,
   profile: null,
@@ -33,7 +37,7 @@ const AuthContext = createContext<AuthContextType>({
 
 export const useAuth = () => useContext(AuthContext);
 
-export function AuthProvider({ children }: { children: React.ReactNode }) {
+export function AuthProvider({ children }: Readonly<AuthProviderProps>) {
   const [firebaseUser, setFirebaseUser] = useState<User | null>(null);
   const [profile, setProfile] = useState<UserProfile | null>(null);
   const [loading, setLoading] = useState(true);


### PR DESCRIPTION
Summary
- Refactored React component prop typings to use named interfaces.
- Wrapped component prop interfaces with `Readonly` to follow the required project style.
- This makes component declarations shorter, cleaner, and more consistent across the project.

Changes
- Added new prop interfaces for components that previously used inline prop object types.
- Updated existing component prop usages from `ComponentProps` to `Readonly<ComponentProps>`.
- Refactored affected components in dashboard, admin, layout, provider, context, room status, message, and shared component files.
- Left API route handler parameter types unchanged because they are not React component props.

Checklist
- [x] Code follows project guidelines.
- [x] Tested locally and works as expected.
- [x] No breaking changes to existing features.