### PR TITLE
3A-G04-W004-PR02. Creation of Component Props Interface

### DIFF
--- a/app/(auth)/register/page.tsx
+++ b/app/(auth)/register/page.tsx
@@ -7,6 +7,10 @@ import Toast from '@/components/ui/Toast';
 import { USER_ROLES } from '@/lib/auth/roles';
 import { registerWithEmail, getAuthErrorMessage } from '@/lib/auth/auth';
 
+interface EyeIconProps {
+  open: boolean;
+}
+
 function RegisterForm() {
   const searchParams = useSearchParams();
   const roleParam = searchParams.get('role') || 'student';
@@ -83,7 +87,7 @@ function RegisterForm() {
     }
   };
 
-  const EyeIcon = ({ open }: { open: boolean }) => open ? (
+  const EyeIcon = ({ open }: Readonly<EyeIconProps>) => open ? (
     <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
       <path strokeLinecap="round" strokeLinejoin="round" d="M13.875 18.825A10.05 10.05 0 0112 19c-5 0-9.27-3.11-11-7.5a11.72 11.72 0 013.168-4.477M6.343 6.343A9.97 9.97 0 0112 5c5 0 9.27 3.11 11 7.5a11.72 11.72 0 01-4.168 4.477M6.343 6.343L3 3m3.343 3.343l2.829 2.829m4.243 4.243L17.657 17.657M17.657 17.657L21 21m-3.343-3.343l-2.829-2.829a3 3 0 00-4.243-4.243" />
     </svg>

--- a/app/(main)/dashboard/inbox/page.tsx
+++ b/app/(main)/dashboard/inbox/page.tsx
@@ -21,7 +21,23 @@ import {
   type Reservation,
 } from '@/lib/reservations/reservations';
 
-function StatusBadge({ status }: { status: string }) {
+interface StatusBadgeProps {
+  status: string;
+}
+
+interface ReservationApprovalsProps {
+  email: string;
+  targetReservationId: string | null;
+}
+
+interface UserInboxProps {
+  canCompose: boolean;
+  email: string;
+  isFaculty: boolean;
+  uid: string;
+}
+
+function StatusBadge({ status }: Readonly<StatusBadgeProps>) {
   const style = (() => {
     switch (status) {
       case 'pending':
@@ -56,10 +72,7 @@ function formatEquipment(equipment?: Record<string, number>) {
 function ReservationApprovals({
   email,
   targetReservationId,
-}: {
-  email: string;
-  targetReservationId: string | null;
-}) {
+}: Readonly<ReservationApprovalsProps>) {
   const { firebaseUser, profile } = useAuth();
   const [requests, setRequests] = useState<Reservation[]>([]);
   const [actionLoading, setActionLoading] = useState<string | null>(null);
@@ -358,12 +371,7 @@ function UserInbox({
   email,
   isFaculty,
   uid,
-}: {
-  canCompose: boolean;
-  email: string;
-  isFaculty: boolean;
-  uid: string;
-}) {
+}: Readonly<UserInboxProps>) {
   const [composeOpen, setComposeOpen] = useState(false);
   const [notifications, setNotifications] = useState<AppNotification[]>([]);
   const searchParams = useSearchParams();

--- a/app/(main)/dashboard/layout.tsx
+++ b/app/(main)/dashboard/layout.tsx
@@ -5,10 +5,12 @@ export const metadata: Metadata = {
   title: "iRoomReserve | Dashboard",
 }
 
+interface DashboardLayoutProps {
+  children: React.ReactNode;
+}
+
 export default function DashboardLayout({
   children
-}: {
-  children: React.ReactNode
-}) {
+}: Readonly<DashboardLayoutProps>) {
   return <DashboardLayoutClient>{children}</DashboardLayoutClient>
 }

--- a/app/admin/layout.tsx
+++ b/app/admin/layout.tsx
@@ -8,6 +8,10 @@ import { useAuth } from '@/context/AuthContext';
 import { useAdminTab } from '@/context/AdminTabContext';
 import { normalizeRole, USER_ROLES } from '@/lib/auth/roles';
 
+interface AdminLayoutProps {
+  children: React.ReactNode;
+}
+
 function LoadingState() {
   return (
     <div className="min-h-screen flex items-center justify-center">
@@ -38,7 +42,7 @@ function LoadingState() {
   );
 }
 
-export default function AdminLayout({ children }: { children: React.ReactNode }) {
+export default function AdminLayout({ children }: Readonly<AdminLayoutProps>) {
   const { firebaseUser, profile, loading, logout } = useAuth();
   const { activeTab, setActiveTab } = useAdminTab();
   const router = useRouter();

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -45,11 +45,13 @@ export const metadata: Metadata = {
   manifest: "/manifest.json",
 };
 
+interface RootLayoutProps {
+  children: React.ReactNode;
+}
+
 export default function RootLayout({
   children,
-}: Readonly<{
-  children: React.ReactNode;
-}>) {
+}: Readonly<RootLayoutProps>) {
   return (
     <html lang="en" className="bg-[#f8f9fa]">
       <body suppressHydrationWarning className={`min-h-screen bg-[#f8f9fa] ${centuryGothicRegular.variable} ${centuryGothicBold.variable}`}>

--- a/components/admin/AdminClassSchedulesSection.tsx
+++ b/components/admin/AdminClassSchedulesSection.tsx
@@ -80,7 +80,7 @@ export default function AdminClassSchedulesSection({
   onSaveSchedule,
   onEditSchedule,
   className = '',
-}: AdminClassSchedulesSectionProps) {
+}: Readonly<AdminClassSchedulesSectionProps>) {
   const timetableDays = DAY_NAMES.map((label, value) => ({ label, value })).filter(
     (day) => day.value >= 1 && day.value <= 6
   );

--- a/components/admin/AdminNoBuildingAssigned.tsx
+++ b/components/admin/AdminNoBuildingAssigned.tsx
@@ -8,7 +8,7 @@ interface AdminNoBuildingAssignedProps {
 export default function AdminNoBuildingAssigned({
   title = 'No Building Assigned',
   description = 'Your account has been approved, but the Super Admin has not yet assigned a building to you. Please contact the Super Admin to get a building assignment.',
-}: AdminNoBuildingAssignedProps) {
+}: Readonly<AdminNoBuildingAssignedProps>) {
   return (
     <div className="glass-card p-12 text-center">
       <div className="w-16 h-16 rounded-full bg-yellow-500/10 flex items-center justify-center mx-auto mb-4">

--- a/components/admin/AdminPageHeader.tsx
+++ b/components/admin/AdminPageHeader.tsx
@@ -24,7 +24,7 @@ export default function AdminPageHeader({
   activeBuildingLabel,
   onBuildingChange,
   integratedBuildingField = false,
-}: AdminPageHeaderProps) {
+}: Readonly<AdminPageHeaderProps>) {
   if (integratedBuildingField) {
     return (
       <section className="w-full rounded-xl bg-white px-6 py-5 shadow-[0_2px_8px_rgba(0,0,0,0.08)]">

--- a/components/admin/AdminRoomStatusSection.tsx
+++ b/components/admin/AdminRoomStatusSection.tsx
@@ -20,7 +20,11 @@ interface AdminRoomStatusSectionProps {
   className?: string;
 }
 
-function StatusBadge({ status }: { status: string }) {
+interface StatusBadgeProps {
+  status: string;
+}
+
+function StatusBadge({ status }: Readonly<StatusBadgeProps>) {
   const style = (() => {
     switch (status) {
       case 'Unavailable':
@@ -48,7 +52,7 @@ export default function AdminRoomStatusSection({
   computeEffectiveStatus,
   onStatusChange,
   className = '',
-}: AdminRoomStatusSectionProps) {
+}: Readonly<AdminRoomStatusSectionProps>) {
   return (
     <section className={className}>
       {rooms.length === 0 ? (

--- a/components/admin/dashboard/AdminFeedbackTab.tsx
+++ b/components/admin/dashboard/AdminFeedbackTab.tsx
@@ -22,7 +22,7 @@ export default function AdminFeedbackTab({
   feedbackList,
   feedbackSummary,
   onReload,
-}: AdminFeedbackTabProps) {
+}: Readonly<AdminFeedbackTabProps>) {
   const [respondingId, setRespondingId] = useState<string | null>(null);
   const [responseText, setResponseText] = useState('');
 

--- a/components/admin/dashboard/AdminManageRoomsTab.tsx
+++ b/components/admin/dashboard/AdminManageRoomsTab.tsx
@@ -39,6 +39,10 @@ interface AdminManageRoomsTabProps {
     onBuildingChange: (buildingId: string) => void;
 }
 
+interface IconProps {
+    className: string;
+}
+
 function sortFloors(floors: string[]) {
     return [...floors].sort((left, right) => {
         const floorOrder = (value: string) => {
@@ -71,7 +75,7 @@ function getRoomTypeBadgeLetter(roomType?: string) {
     }
 }
 
-function PlusIcon({ className }: { className: string }) {
+function PlusIcon({ className }: Readonly<IconProps>) {
     return (
         <svg className={className} fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 5v14m7-7H5" />
@@ -79,7 +83,7 @@ function PlusIcon({ className }: { className: string }) {
     );
 }
 
-function SearchIcon({ className }: { className: string }) {
+function SearchIcon({ className }: Readonly<IconProps>) {
     return (
         <svg className={className} fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
@@ -87,7 +91,7 @@ function SearchIcon({ className }: { className: string }) {
     );
 }
 
-function ChevronDownIcon({ className }: { className: string }) {
+function ChevronDownIcon({ className }: Readonly<IconProps>) {
     return (
         <svg className={className} fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19.5 8.25l-7.5 7.5-7.5-7.5" />
@@ -95,7 +99,7 @@ function ChevronDownIcon({ className }: { className: string }) {
     );
 }
 
-function CheckIcon({ className }: { className: string }) {
+function CheckIcon({ className }: Readonly<IconProps>) {
     return (
         <svg className={className} fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4.5 12.75l6 6 9-13.5" />
@@ -103,7 +107,7 @@ function CheckIcon({ className }: { className: string }) {
     );
 }
 
-function PencilIcon({ className }: { className: string }) {
+function PencilIcon({ className }: Readonly<IconProps>) {
     return (
         <svg className={className} fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M16.862 4.487l1.688-1.688a1.875 1.875 0 112.652 2.652L10.582 16.07a4.5 4.5 0 01-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 011.13-1.897l8.932-8.931z" />
@@ -112,7 +116,7 @@ function PencilIcon({ className }: { className: string }) {
     );
 }
 
-function TrashIcon({ className }: { className: string }) {
+function TrashIcon({ className }: Readonly<IconProps>) {
     return (
         <svg className={className} fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M14.74 9l-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166M19.228 5.79L18.16 19.673A2.25 2.25 0 0115.916 21H8.084a2.25 2.25 0 01-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 00-3.478-.397m-12 .563c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 013.478-.397m7.5 0v-.916A2.25 2.25 0 0013.5 2.25h-3A2.25 2.25 0 008.25 4.5v.916m7.5 0a48.667 48.667 0 00-7.5 0" />
@@ -127,7 +131,7 @@ export default function AdminManageRoomsTab({
     buildingName,
     managedBuildings,
     onBuildingChange,
-}: AdminManageRoomsTabProps) {
+}: Readonly<AdminManageRoomsTabProps>) {
     const [addRoomStep, setAddRoomStep] = useState(0);
     const [newRoomName, setNewRoomName] = useState('');
     const [newRoomFloor, setNewRoomFloor] = useState('');

--- a/components/admin/dashboard/AdminOverviewTab.tsx
+++ b/components/admin/dashboard/AdminOverviewTab.tsx
@@ -37,6 +37,22 @@ interface AdminOverviewTabProps {
   unavailableCount: number;
 }
 
+interface DashboardSectionProps {
+  action?: ReactNode;
+  children: ReactNode;
+  className?: string;
+  eyebrow?: string;
+  title: string;
+}
+
+interface SummaryMetricCardProps {
+  action?: () => void;
+  detail?: string;
+  label: string;
+  tone: string;
+  value: number;
+}
+
 const ROOM_FILTERS: RoomStatusFilter[] = [
   'All',
   'Available',
@@ -54,13 +70,7 @@ function DashboardSection({
   className = '',
   eyebrow,
   title,
-}: {
-  action?: ReactNode;
-  children: ReactNode;
-  className?: string;
-  eyebrow?: string;
-  title: string;
-}) {
+}: Readonly<DashboardSectionProps>) {
   return (
     <section className={`glass-card p-3 sm:p-4 ${className}`.trim()}>
       <div className="mb-3 flex items-start justify-between gap-3">
@@ -85,13 +95,7 @@ function SummaryMetricCard({
   label,
   tone,
   value,
-}: {
-  action?: () => void;
-  detail?: string;
-  label: string;
-  tone: string;
-  value: number;
-}) {
+}: Readonly<SummaryMetricCardProps>) {
   const content = (
     <>
       <div className={`mb-2 h-1 w-8 rounded-full ${tone}`} />
@@ -161,7 +165,7 @@ export default function AdminOverviewTab({
   rooms,
   setActiveTab,
   unavailableCount,
-}: AdminOverviewTabProps) {
+}: Readonly<AdminOverviewTabProps>) {
   const [roomSearch, setRoomSearch] = useState('');
   const [roomStatusFilter, setRoomStatusFilter] = useState<RoomStatusFilter>('All');
   const [previewRooms, setPreviewRooms] = useState<Room[]>(rooms);

--- a/components/admin/dashboard/AdminPendingTab.tsx
+++ b/components/admin/dashboard/AdminPendingTab.tsx
@@ -24,7 +24,11 @@ interface AdminPendingTabProps {
   onReload: () => Promise<void>;
 }
 
-function ChevronDownIcon({ className }: { className: string }) {
+interface IconProps {
+  className: string;
+}
+
+function ChevronDownIcon({ className }: Readonly<IconProps>) {
   return (
     <svg className={className} fill="none" stroke="currentColor" viewBox="0 0 24 24">
       <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19.5 8.25l-7.5 7.5-7.5-7.5" />
@@ -32,7 +36,7 @@ function ChevronDownIcon({ className }: { className: string }) {
   );
 }
 
-function CheckIcon({ className }: { className: string }) {
+function CheckIcon({ className }: Readonly<IconProps>) {
   return (
     <svg className={className} fill="none" stroke="currentColor" viewBox="0 0 24 24">
       <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4.5 12.75l6 6 9-13.5" />
@@ -48,7 +52,7 @@ export default function AdminPendingTab({
   managedBuildings,
   onBuildingChange,
   onReload,
-}: AdminPendingTabProps) {
+}: Readonly<AdminPendingTabProps>) {
   const [actionLoading, setActionLoading] = useState<string | null>(null);
   const [rejectingReservationId, setRejectingReservationId] = useState<string | null>(null);
   const [rejectReason, setRejectReason] = useState('');

--- a/components/admin/dashboard/AdminRoomHistoryTab.tsx
+++ b/components/admin/dashboard/AdminRoomHistoryTab.tsx
@@ -42,7 +42,7 @@ function getHistoryDateValue(date: string) {
 
 export default function AdminRoomHistoryTab({
   roomHistory,
-}: AdminRoomHistoryTabProps) {
+}: Readonly<AdminRoomHistoryTabProps>) {
   const currentDate = new Date();
   const currentYear = currentDate.getFullYear();
   const currentMonth = currentDate.getMonth();

--- a/components/admin/dashboard/shared.tsx
+++ b/components/admin/dashboard/shared.tsx
@@ -1,6 +1,18 @@
 import { formatDate } from '@/lib/utils/dateTime';
 
-export function RoleBadge({ role }: { role: string }) {
+interface RoleBadgeProps {
+  role: string;
+}
+
+interface StatusBadgeProps {
+  status: string;
+}
+
+interface StarRatingProps {
+  rating: number;
+}
+
+export function RoleBadge({ role }: Readonly<RoleBadgeProps>) {
   const style = role === 'Faculty Professor' ? 'ui-badge-green' : 'ui-badge-blue';
 
   return (
@@ -10,7 +22,7 @@ export function RoleBadge({ role }: { role: string }) {
   );
 }
 
-export function StatusBadge({ status }: { status: string }) {
+export function StatusBadge({ status }: Readonly<StatusBadgeProps>) {
   const style = (() => {
     switch (status) {
       case 'Occupied':
@@ -41,7 +53,7 @@ export function StatusBadge({ status }: { status: string }) {
   );
 }
 
-export function StarRating({ rating }: { rating: number }) {
+export function StarRating({ rating }: Readonly<StarRatingProps>) {
   return (
     <div className="flex items-center gap-0.5">
       {[1, 2, 3, 4, 5].map((star) => (

--- a/components/auth/AuthAlert.tsx
+++ b/components/auth/AuthAlert.tsx
@@ -69,7 +69,7 @@ export default function AuthAlert({
   message,
   tone = 'error',
   className = '',
-}: AuthAlertProps) {
+}: Readonly<AuthAlertProps>) {
   const toneStyle = alertToneStyles[tone];
   return (
     <div

--- a/components/ble/BeaconStatusSection.tsx
+++ b/components/ble/BeaconStatusSection.tsx
@@ -19,7 +19,7 @@ export default function BeaconStatusSection({
   buildingName,
   rooms,
   title = 'Beacon Status',
-}: BeaconStatusSectionProps) {
+}: Readonly<BeaconStatusSectionProps>) {
   const sortedRooms = [...rooms].sort(compareRooms);
   const occupiedCount = rooms.filter((room) => room.beaconConnected).length;
   const availableCount = rooms.length - occupiedCount;

--- a/components/ble/BleAdminMonitor.tsx
+++ b/components/ble/BleAdminMonitor.tsx
@@ -63,7 +63,7 @@ export default function BleAdminMonitor({
   rooms,
   className = '',
   pollIntervalMs = BLE_MONITOR_REFRESH_INTERVAL_MS,
-}: BleAdminMonitorProps) {
+}: Readonly<BleAdminMonitorProps>) {
   const [occupancyData, setOccupancyData] = useState<OccupancyPayload>(
     DEFAULT_OCCUPANCY_PAYLOAD
   );

--- a/components/ble/BleStatus.tsx
+++ b/components/ble/BleStatus.tsx
@@ -76,7 +76,7 @@ export default function BleStatus({
   room,
   className = '',
   pollIntervalMs = BLE_MONITOR_REFRESH_INTERVAL_MS,
-}: BleStatusProps) {
+}: Readonly<BleStatusProps>) {
   const { firebaseUser, loading } = useAuth();
   const [occupancyStatus, setOccupancyStatus] = useState<OccupancyPayload>(
     DEFAULT_OCCUPANCY_PAYLOAD

--- a/components/dashboards/AdminDashboard.tsx
+++ b/components/dashboards/AdminDashboard.tsx
@@ -41,7 +41,7 @@ function getLocalDateKey(date: Date = new Date()) {
 export default function AdminDashboard({
   firstName,
   activeTab,
-}: AdminDashboardProps) {
+}: Readonly<AdminDashboardProps>) {
   const { firebaseUser, profile } = useAuth();
   const { setActiveTab, selectedBuildingId, setSelectedBuildingId } = useAdminTab();
 

--- a/components/dashboards/FacultyDashboard.tsx
+++ b/components/dashboards/FacultyDashboard.tsx
@@ -9,6 +9,6 @@ interface FacultyDashboardProps {
 
 export default function FacultyDashboard({
   firstName,
-}: FacultyDashboardProps) {
+}: Readonly<FacultyDashboardProps>) {
   return <MemberDashboard firstName={firstName} welcomeEmoji="📚" />;
 }

--- a/components/dashboards/MemberDashboard.tsx
+++ b/components/dashboards/MemberDashboard.tsx
@@ -27,7 +27,7 @@ interface MemberDashboardProps {
 export default function MemberDashboard({
   firstName,
   welcomeEmoji,
-}: MemberDashboardProps) {
+}: Readonly<MemberDashboardProps>) {
   const { firebaseUser } = useAuth();
   const uid = firebaseUser?.uid;
   const {

--- a/components/dashboards/StudentDashboard.tsx
+++ b/components/dashboards/StudentDashboard.tsx
@@ -9,6 +9,6 @@ interface StudentDashboardProps {
 
 export default function StudentDashboard({
   firstName,
-}: StudentDashboardProps) {
+}: Readonly<StudentDashboardProps>) {
   return <MemberDashboard firstName={firstName} welcomeEmoji="🎓" />;
 }

--- a/components/dashboards/UtilityStaffDashboard.tsx
+++ b/components/dashboards/UtilityStaffDashboard.tsx
@@ -36,7 +36,7 @@ interface UtilityStaffDashboardProps {
 
 export default function UtilityStaffDashboard({
   firstName,
-}: UtilityStaffDashboardProps) {
+}: Readonly<UtilityStaffDashboardProps>) {
   const { firebaseUser, profile } = useAuth();
   const uid = firebaseUser?.uid;
   const managedBuildings = getManagedBuildingsForCampus(profile?.campus);

--- a/components/layout/DashboardLayoutClient.tsx
+++ b/components/layout/DashboardLayoutClient.tsx
@@ -8,7 +8,11 @@ import { useAdminTab } from '@/context/AdminTabContext';
 import { USER_ROLES } from '@/lib/auth/roles';
 import Link from 'next/link';
 
-function DashboardLayoutInner({ children }: { children: React.ReactNode }) {
+interface DashboardLayoutProps {
+  children: React.ReactNode;
+}
+
+function DashboardLayoutInner({ children }: Readonly<DashboardLayoutProps>) {
   const { firebaseUser, profile, loading, logout } = useAuth();
   const router = useRouter();
   const pathname = usePathname();
@@ -229,6 +233,6 @@ function DashboardLayoutInner({ children }: { children: React.ReactNode }) {
   );
 }
 
-export default function DashboardLayout({ children }: { children: React.ReactNode }) {
+export default function DashboardLayout({ children }: Readonly<DashboardLayoutProps>) {
   return <DashboardLayoutInner>{children}</DashboardLayoutInner>;
 }

--- a/components/layout/NavBar.tsx
+++ b/components/layout/NavBar.tsx
@@ -34,6 +34,10 @@ interface NavBarProps {
   onTabChange?: (tab: AdminTab) => void;
 }
 
+interface ChevronDownIconProps {
+  open: boolean;
+}
+
 const adminLinks: Array<{ label: string; tab: AdminTab }> = [
   { label: 'Dashboard', tab: 'dashboard' },
   { label: 'Pending', tab: 'pending' },
@@ -55,7 +59,7 @@ const navItemActiveClasses = 'bg-transparent text-[#a12124] shadow-none';
 const navItemInactiveClasses =
   'bg-transparent text-[#343434] hover:bg-transparent hover:text-[#a12124] hover:shadow-none';
 
-function ChevronDownIcon({ open }: { open: boolean }) {
+function ChevronDownIcon({ open }: Readonly<ChevronDownIconProps>) {
   return (
     <svg
       className={`w-4 h-4 transition-transform duration-200 ${open ? 'rotate-180' : ''}`}
@@ -73,7 +77,7 @@ function ChevronDownIcon({ open }: { open: boolean }) {
   );
 }
 
-const NavBar: React.FC<NavBarProps> = ({
+const NavBar: React.FC<Readonly<NavBarProps>> = ({
   user,
   onLogout,
   activeTab,

--- a/components/layout/NavBar.tsx
+++ b/components/layout/NavBar.tsx
@@ -205,7 +205,11 @@ const NavBar: React.FC<Readonly<NavBarProps>> = ({
   };
 
   const handleNotificationClick = async (notification: Notification) => {
-    await markNotificationRead(notification.id);
+    const isPending = notification.type === 'new_reservation'
+
+    if (!isPending) {
+      await markNotificationRead(notification.id);
+    }
     setShowNotifications(false);
 
     if (notification.reservationId) {

--- a/components/layout/Providers.tsx
+++ b/components/layout/Providers.tsx
@@ -3,7 +3,11 @@
 import { AuthProvider } from '@/context/AuthContext';
 import { AdminTabProvider } from '@/context/AdminTabContext';
 
-export default function Providers({ children }: { children: React.ReactNode }) {
+interface ProvidersProps {
+  children: React.ReactNode;
+}
+
+export default function Providers({ children }: Readonly<ProvidersProps>) {
   return (
     <AuthProvider>
       <AdminTabProvider>{children}</AdminTabProvider>

--- a/components/messages/ComposeModal.tsx
+++ b/components/messages/ComposeModal.tsx
@@ -27,7 +27,7 @@ export default function ComposeModal({
   initialRecipientId = '',
   initialSubject = '',
   initialBody = '',
-}: ComposeModalProps) {
+}: Readonly<ComposeModalProps>) {
   const { firebaseUser, profile } = useAuth();
   const [recipients, setRecipients] = useState<MessageRecipient[]>([]);
   const [recipientsError, setRecipientsError] = useState('');

--- a/components/messages/MessagesSection.tsx
+++ b/components/messages/MessagesSection.tsx
@@ -167,7 +167,34 @@ function getReservationUpdateNote(
   return 'No additional note provided.';
 }
 
-function StatusBadge({ status }: { status: ReservationUpdateStatus }) {
+interface StatusBadgeProps {
+  status: ReservationUpdateStatus;
+}
+
+interface EmptyStateProps {
+  description: string;
+  title: string;
+}
+
+interface DetailFieldProps {
+  children: React.ReactNode;
+  className?: string;
+  label: string;
+}
+
+interface DateFilterControlsProps {
+  customFrom: string;
+  customRange: CustomDateRange | null;
+  customTo: string;
+  onApplyCustomRange: () => void;
+  onClearCustomRange: () => void;
+  onCustomFromChange: (value: string) => void;
+  onCustomToChange: (value: string) => void;
+  onPresetChange: (preset: DatePreset) => void;
+  preset: DatePreset;
+}
+
+function StatusBadge({ status }: Readonly<StatusBadgeProps>) {
   const style = (() => {
     switch (status) {
       case 'approved':
@@ -195,10 +222,7 @@ function StatusBadge({ status }: { status: ReservationUpdateStatus }) {
 function EmptyState({
   description,
   title,
-}: {
-  description: string;
-  title: string;
-}) {
+}: Readonly<EmptyStateProps>) {
   return (
     <div className="rounded-3xl border border-dark/5 bg-white/70 p-10 text-center">
       <p className="text-sm font-bold text-black">{title}</p>
@@ -211,11 +235,7 @@ function DetailField({
   children,
   className = '',
   label,
-}: {
-  children: React.ReactNode;
-  className?: string;
-  label: string;
-}) {
+}: Readonly<DetailFieldProps>) {
   return (
     <div className={`rounded-2xl border border-dark/5 bg-dark/3 p-3 ${className}`}>
       <p className="mb-1 text-[10px] font-bold uppercase tracking-wider text-black/55">
@@ -236,17 +256,7 @@ function DateFilterControls({
   onCustomToChange,
   onPresetChange,
   preset,
-}: {
-  customFrom: string;
-  customRange: CustomDateRange | null;
-  customTo: string;
-  onApplyCustomRange: () => void;
-  onClearCustomRange: () => void;
-  onCustomFromChange: (value: string) => void;
-  onCustomToChange: (value: string) => void;
-  onPresetChange: (preset: DatePreset) => void;
-  preset: DatePreset;
-}) {
+}: Readonly<DateFilterControlsProps>) {
   const canApplyCustomRange = Boolean(customFrom && customTo);
   const canClearCustomRange = Boolean(customFrom || customTo || customRange);
 
@@ -320,7 +330,7 @@ function DateFilterControls({
   );
 }
 
-export default function MessagesSection(props: MessagesSectionProps) {
+export default function MessagesSection(props: Readonly<MessagesSectionProps>) {
   const { firebaseUser, profile } = useAuth();
   const registerComposeOpener = props.registerComposeOpener;
   const notifications = useMemo(

--- a/components/room-status/BuildingSection.tsx
+++ b/components/room-status/BuildingSection.tsx
@@ -12,7 +12,7 @@ interface BuildingSectionProps {
 export default function BuildingSection({
   building,
   floors,
-}: BuildingSectionProps) {
+}: Readonly<BuildingSectionProps>) {
   return (
     <section className="glass-card p-4 sm:p-5">
       <div className="mb-4">

--- a/components/room-status/CampusSelector.tsx
+++ b/components/room-status/CampusSelector.tsx
@@ -13,7 +13,7 @@ export default function CampusSelector({
   onChange,
   options,
   value,
-}: CampusSelectorProps) {
+}: Readonly<CampusSelectorProps>) {
   if (options.length === 0) {
     return null;
   }

--- a/components/room-status/FloorAccordion.tsx
+++ b/components/room-status/FloorAccordion.tsx
@@ -12,7 +12,7 @@ export default function FloorAccordion({
   floor,
   roomCount,
   renderContent,
-}: FloorAccordionProps) {
+}: Readonly<FloorAccordionProps>) {
   const [isOpen, setIsOpen] = useState(false);
 
   return (

--- a/components/room-status/RoomList.tsx
+++ b/components/room-status/RoomList.tsx
@@ -31,7 +31,7 @@ function getReservationMeta(item: RoomStatusViewItem) {
   return 'No active reservation';
 }
 
-export default function RoomList({ items }: RoomListProps) {
+export default function RoomList({ items }: Readonly<RoomListProps>) {
   if (items.length === 0) {
     return (
       <div className="rounded-2xl border border-dark/10 bg-dark/5 p-6 text-center">

--- a/components/rooms/RoomAssistantWidget.tsx
+++ b/components/rooms/RoomAssistantWidget.tsx
@@ -310,7 +310,7 @@ export default function RoomAssistantWidget({
   timeslot,
   requestOpen = false,
   onRequestOpenHandled,
-}: RoomAssistantWidgetProps) {
+}: Readonly<RoomAssistantWidgetProps>) {
   const welcomeMessage = useMemo(() => createWelcomeMessage(), []);
   const [isOpen, setIsOpen] = useState(false);
   const [messages, setMessages] = useState<AssistantMessage[]>([welcomeMessage]);

--- a/components/rooms/RoomAvailabilityPicker.tsx
+++ b/components/rooms/RoomAvailabilityPicker.tsx
@@ -51,7 +51,7 @@ export default function RoomAvailabilityPicker({
   loading = false,
   hideLegend = false,
   className = '',
-}: RoomAvailabilityPickerProps) {
+}: Readonly<RoomAvailabilityPickerProps>) {
   const minSelectable = minDate ?? todayAtMidnight;
 
   const partiallyBookedDateObjects = useMemo(

--- a/components/rooms/RoomCard.tsx
+++ b/components/rooms/RoomCard.tsx
@@ -32,7 +32,7 @@ export default function RoomCard({
   name,
   onClick,
   roomType,
-}: RoomCardProps) {
+}: Readonly<RoomCardProps>) {
   const isAvailable = availability === 'Available';
 
   return (

--- a/components/rooms/schedules/DaySchedulePanel.tsx
+++ b/components/rooms/schedules/DaySchedulePanel.tsx
@@ -68,7 +68,7 @@ export default function DaySchedulePanel({
   campusTimeRange,
   onSelectSlot,
   onRequestAlternatives,
-}: DaySchedulePanelProps) {
+}: Readonly<DaySchedulePanelProps>) {
   const [toast, setToast] = useState<{
     message: string;
     type: 'info' | 'warning' | 'error';

--- a/components/rooms/schedules/MyReservationTimetable.tsx
+++ b/components/rooms/schedules/MyReservationTimetable.tsx
@@ -1,7 +1,7 @@
 import type { Reservation } from '@/lib/reservations/reservations';
 import { formatTimeRange } from '@/lib/utils/dateTime';
 
-type MyReservationTimetableProps = {
+interface MyReservationTimetableProps {
   className?: string;
   compact?: boolean;
   compactVariant?: 'weekly' | 'today';
@@ -104,7 +104,7 @@ export default function MyReservationTimetable({
   compactVariant = 'weekly',
   currentUserId,
   reservations,
-}: MyReservationTimetableProps) {
+}: Readonly<MyReservationTimetableProps>) {
   const entriesByDay = buildEntriesByDay(reservations, currentUserId);
 
   if (compact) {

--- a/components/rooms/schedules/TodayClassSchedulesPanel.tsx
+++ b/components/rooms/schedules/TodayClassSchedulesPanel.tsx
@@ -13,17 +13,17 @@ import {
 type ScheduleCampusFilter = 'SDCA Digi Campus' | 'SDCA Main Campus';
 type ScheduleBuildingFilter = 'gd1' | 'gd2' | 'gd3';
 
-type TodayClassSchedulesPanelProps =
-  | {
-      className?: string;
-      scope: 'campus';
-    }
-  | {
-      buildingId: string;
-      buildingName: string;
-      className?: string;
-      scope: 'building';
-    };
+interface TodayClassSchedulesPanelProps {
+  buildingId?: string;
+  buildingName?: string;
+  className?: string;
+  scope: 'campus' | 'building';
+}
+
+interface EmptyStateProps {
+  description?: string;
+  title: string;
+}
 
 const SCHEDULE_DAY_OPTIONS = [
   { label: 'Monday', value: 1 },
@@ -61,10 +61,7 @@ function getDefaultSelectedDay() {
 function EmptyState({
   description,
   title,
-}: {
-  description?: string;
-  title: string;
-}) {
+}: Readonly<EmptyStateProps>) {
   return (
     <div className="p-12 text-center">
       <svg
@@ -87,7 +84,7 @@ function EmptyState({
 }
 
 export default function TodayClassSchedulesPanel(
-  props: TodayClassSchedulesPanelProps
+  props: Readonly<TodayClassSchedulesPanelProps>
 ) {
   const [selectedDay, setSelectedDay] = useState<string>(getDefaultSelectedDay);
   const [selectedCampus, setSelectedCampus] = useState<ScheduleCampusFilter | null>(

--- a/components/ui/BleStatusBadge.tsx
+++ b/components/ui/BleStatusBadge.tsx
@@ -49,7 +49,7 @@ export default function BleStatusBadge({
   status,
   label,
   className = '',
-}: BleStatusBadgeProps) {
+}: Readonly<BleStatusBadgeProps>) {
   const theme = getBleBadgeTheme(status);
 
   return (

--- a/components/ui/BleSummaryCard.tsx
+++ b/components/ui/BleSummaryCard.tsx
@@ -48,7 +48,7 @@ export default function BleSummaryCard({
   detailsHref = '/dashboard/room-status',
   onViewDetails,
   variant = 'default',
-}: BleSummaryCardProps) {
+}: Readonly<BleSummaryCardProps>) {
   const [occupancyData, setOccupancyData] = useState<OccupancyPayload>(
     DEFAULT_OCCUPANCY_PAYLOAD
   );

--- a/components/ui/StatusBadge.tsx
+++ b/components/ui/StatusBadge.tsx
@@ -71,7 +71,7 @@ function getBadgeLabel(status: string): string {
   }
 }
 
-const StatusBadge: React.FC<StatusBadgeProps> = ({ status, className = '' }) => {
+const StatusBadge: React.FC<Readonly<StatusBadgeProps>> = ({ status, className = '' }) => {
   return (
     <span
       className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-bold border leading-5 ${getBadgeStyle(status)} ${className}`.trim()}

--- a/components/ui/SummaryCard.tsx
+++ b/components/ui/SummaryCard.tsx
@@ -9,7 +9,7 @@ interface SummaryCardProps {
   color: string;
 }
 
-const SummaryCard: React.FC<SummaryCardProps> = ({ icon, number, label, color }) => {
+const SummaryCard: React.FC<Readonly<SummaryCardProps>> = ({ icon, number, label, color }) => {
   return (
     <div className={`glass-card p-6 border-l-4 ${color}`}>
       <div className="flex items-center">

--- a/components/ui/Toast.tsx
+++ b/components/ui/Toast.tsx
@@ -10,7 +10,7 @@ interface ToastProps {
   duration?: number;
 }
 
-export default function Toast({ message, type = 'success', show, onClose, duration = 3000 }: ToastProps) {
+export default function Toast({ message, type = 'success', show, onClose, duration = 3000 }: Readonly<ToastProps>) {
   const [visible, setVisible] = useState(false);
   const [animating, setAnimating] = useState(false);
 

--- a/context/AdminTabContext.tsx
+++ b/context/AdminTabContext.tsx
@@ -10,6 +10,10 @@ interface AdminTabContextType {
   setSelectedBuildingId: (buildingId: string) => void;
 }
 
+interface AdminTabProviderProps {
+  children: React.ReactNode;
+}
+
 const AdminTabContext = createContext<AdminTabContextType>({
   activeTab: 'dashboard',
   setActiveTab: () => {},
@@ -17,7 +21,7 @@ const AdminTabContext = createContext<AdminTabContextType>({
   setSelectedBuildingId: () => {},
 });
 
-export function AdminTabProvider({ children }: { children: React.ReactNode }) {
+export function AdminTabProvider({ children }: Readonly<AdminTabProviderProps>) {
   const [activeTab, setActiveTab] = useState<AdminTab>('dashboard');
   const [selectedBuildingId, setSelectedBuildingId] = useState('');
   return (

--- a/context/AuthContext.tsx
+++ b/context/AuthContext.tsx
@@ -24,6 +24,10 @@ interface AuthContextType {
   logout: () => Promise<void>;
 }
 
+interface AuthProviderProps {
+  children: React.ReactNode;
+}
+
 const AuthContext = createContext<AuthContextType>({
   firebaseUser: null,
   profile: null,
@@ -33,7 +37,7 @@ const AuthContext = createContext<AuthContextType>({
 
 export const useAuth = () => useContext(AuthContext);
 
-export function AuthProvider({ children }: { children: React.ReactNode }) {
+export function AuthProvider({ children }: Readonly<AuthProviderProps>) {
   const [firebaseUser, setFirebaseUser] = useState<User | null>(null);
   const [profile, setProfile] = useState<UserProfile | null>(null);
   const [loading, setLoading] = useState(true);


### PR DESCRIPTION
## Changes
- Added local prop interfaces for components that previously declared props inline.
- Updated existing component prop interfaces to be used with `Readonly`.
- Applied the change across layout, dashboard, admin, messages, room, schedule, UI, and context components.
- Left API route handler parameter types unchanged because they are not React component props.

## Checklist
- [x] Code follows project guidelines.
- [x] Tested locally and works as expected.
- [x] No breaking changes to existing features.